### PR TITLE
Add GCP Harbor registry to config.json

### DIFF
--- a/docker/docker/config.json
+++ b/docker/docker/config.json
@@ -1,10 +1,13 @@
 {
   "auths": {
-    "https://index.docker.io/v1/":{
+    "https://index.docker.io/v1/": {
       "auth": "DOCKERCREDS"
     },
     "harbor.shipttech.com": {
       "auth": "HARBORCREDS"
+    },
+    "harbor.gcp.shipttech.com": {
+       "auth": "HARBORCREDS"
     }
   }
 }


### PR DESCRIPTION
Adding harbor.gcp.shipttech.com as a registry to test Harbor GCP drone run.